### PR TITLE
Makefile: use DESTDIR/PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 CFLAGS += -Wall -pedantic -std=c99
 CC ?= clang
 BIN_NAME ?= cottage
-SRCS = cottage.c 
+PREFIX ?= /usr/local
+BIN_DIR ?= $(DESTDIR)$(PREFIX)/bin
+SRCS = cottage.c
 
 all:
 	$(CC) $(SRCS) $(CFLAGS) -o $(BIN_NAME)
@@ -14,10 +16,10 @@ clean:
 	@rm -f $(BIN_NAME)
 
 install:
-	@install -m 0755 $(BIN_NAME) /usr/bin
+	@install -m 0755 $(BIN_NAME) -t $(BIN_DIR)
 
 check:
-	@./checkpatch.pl --no-tree --ignore LONG_LINE,NEW_TYPEDEFS,UNNECESSARY_ELSE,MACRO_WITH_FLOW_CONTROL -f cottage.c
+	@./checkpatch.pl --no-tree --ignore LONG_LINE,NEW_TYPEDEFS,UNNECESSARY_ELSE,MACRO_WITH_FLOW_CONTROL -f $(SRCS)
 
 analyse:
 	@scan-build -v -o analyse make debug

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CFLAGS += -Wall -pedantic -std=c99
 CC ?= clang
 BIN_NAME ?= cottage
 PREFIX ?= /usr/local
-BIN_DIR ?= $(DESTDIR)$(PREFIX)/bin
+BIN_DIR ?= $(PREFIX)/bin
 SRCS = cottage.c
 
 all:
@@ -16,7 +16,7 @@ clean:
 	@rm -f $(BIN_NAME)
 
 install:
-	@install -Dm 0755 $(BIN_NAME) -t $(BIN_DIR)
+	@install -Dm 0755 $(BIN_NAME) $(DESTDIR)$(BIN_DIR)/$(BIN_NAME)
 
 check:
 	@./checkpatch.pl --no-tree --ignore LONG_LINE,NEW_TYPEDEFS,UNNECESSARY_ELSE,MACRO_WITH_FLOW_CONTROL -f $(SRCS)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 	@rm -f $(BIN_NAME)
 
 install:
-	@install -m 0755 $(BIN_NAME) -t $(BIN_DIR)
+	@install -Dm 0755 $(BIN_NAME) -t $(BIN_DIR)
 
 check:
 	@./checkpatch.pl --no-tree --ignore LONG_LINE,NEW_TYPEDEFS,UNNECESSARY_ELSE,MACRO_WITH_FLOW_CONTROL -f $(SRCS)


### PR DESCRIPTION
Useful for packaging, e.g. Arch PKGBUILD. I've also replaced cottage.c with the existing $(SRCS).